### PR TITLE
Ensure ads.txt is publicly available

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,12 @@ This project is licensed under the MIT License - see the LICENSE file for detail
 - Set `NEXT_PUBLIC_GOOGLE_ANALYTICS_ID` in a `.env.local` file to enable Google Analytics tracking for page views and affiliate link clicks
 - Regular content updates improve SEO performance
 
+## Google AdSense Verification
+
+1. Update `public/ads.txt` with your AdSense publisher ID.
+2. Deploy the site and confirm `https://yourdomain.com/ads.txt` loads in the browser.
+3. Retry site verification in the AdSense dashboard once the file is reachable.
+
 ## 🖼️ Getting Official Amazon Product Data
 
 **✅ RECOMMENDED: Use Amazon SiteStripe** (see `SITESTRIPE_GUIDE.md`)

--- a/ads.txt
+++ b/ads.txt
@@ -1,1 +1,0 @@
-google.com, pub-2724823807720042, DIRECT, f08c47fec0942fa0

--- a/public/ads.txt
+++ b/public/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-2724823807720042, DIRECT, f08c47fec0942fa0

--- a/vercel.json
+++ b/vercel.json
@@ -29,6 +29,15 @@
           "value": "text/plain"
         }
       ]
+    },
+    {
+      "source": "/ads.txt",
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "text/plain"
+        }
+      ]
     }
   ]
-} 
+}


### PR DESCRIPTION
## Summary
- fix newline in `ads.txt`
- copy `ads.txt` to `public` so it's served at domain root
- configure Vercel to treat `/ads.txt` as plain text
- document AdSense verification steps
- remove root-level `ads.txt` (not needed for deploy)

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6861f20305308332b1ea83ac66410541