### PR TITLE
Add canonical tags across pages

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -3,6 +3,9 @@ import { Metadata } from 'next/types'
 export const metadata: Metadata = {
   title: 'About NextGenStreamer - Your Creator Gear Experts',
   description: 'Learn about NextGenStreamer and our mission to help content creators find the best equipment for their journey.',
+  alternates: {
+    canonical: 'https://nextgenstreamer.com/about'
+  }
 }
 
 export default function AboutPage() {

--- a/app/guides/headphones-vs-earbuds-2025/page.tsx
+++ b/app/guides/headphones-vs-earbuds-2025/page.tsx
@@ -7,7 +7,10 @@ import { getProductByAsin } from '../../../lib/products'
 export const metadata: Metadata = {
   title: 'Headphones vs Earbuds for Gaming & Streaming 2025 | NextGenStreamer',
   description: 'Complete comparison of headphones vs earbuds for gaming, streaming, and content creation. Discover which is better for your needs with detailed pros, cons, and product recommendations.',
-  keywords: 'headphones vs earbuds gaming, best headphones for streaming, gaming headphones comparison, wireless earbuds gaming, content creator headphones 2025'
+  keywords: 'headphones vs earbuds gaming, best headphones for streaming, gaming headphones comparison, wireless earbuds gaming, content creator headphones 2025',
+  alternates: {
+    canonical: 'https://nextgenstreamer.com/guides/headphones-vs-earbuds-2025'
+  }
 }
 
 export default function HeadphonesVsEarbudsPage() {

--- a/app/guides/how-to-monetize-streaming-low-viewers-2025/page.tsx
+++ b/app/guides/how-to-monetize-streaming-low-viewers-2025/page.tsx
@@ -7,6 +7,9 @@ export const metadata = {
   title: 'How to Monetize Your Stream in 2025 (Even with Low Viewers) - NextGenStreamer',
   description: 'Discover proven strategies to start earning money from streaming, even with a small audience. Learn affiliate marketing, sponsorships, donations, and alternative revenue streams.',
   keywords: 'stream monetization, twitch monetization, youtube monetization, small streamer income, streaming revenue, affiliate marketing for streamers',
+  alternates: {
+    canonical: 'https://nextgenstreamer.com/guides/how-to-monetize-streaming-low-viewers-2025'
+  }
 }
 
 export default function MonetizeStreamingGuide() {

--- a/app/guides/how-to-stream-vertical-916-tiktok-reels-shorts-2025/page.tsx
+++ b/app/guides/how-to-stream-vertical-916-tiktok-reels-shorts-2025/page.tsx
@@ -7,6 +7,9 @@ export const metadata = {
   title: 'How to Stream Vertical (9:16) for TikTok, Reels & YouTube Shorts 2025 - NextGenStreamer',
   description: 'Master vertical streaming for TikTok, Instagram Reels, and YouTube Shorts. Complete setup guide with OBS configuration, equipment tips, and content strategies that actually work.',
   keywords: 'vertical streaming, 9:16 streaming, TikTok live streaming, Instagram Reels live, YouTube Shorts streaming, OBS vertical setup, portrait streaming',
+  alternates: {
+    canonical: 'https://nextgenstreamer.com/guides/how-to-stream-vertical-916-tiktok-reels-shorts-2025'
+  }
 }
 
 export default function VerticalStreamingGuide() {

--- a/app/guides/xlr-vs-usb-microphones-2025/page.tsx
+++ b/app/guides/xlr-vs-usb-microphones-2025/page.tsx
@@ -7,7 +7,10 @@ import { getProductByAsin } from '../../../lib/products'
 export const metadata: Metadata = {
   title: 'XLR vs USB Microphones: Complete Guide 2025 | NextGenStreamer',
   description: 'Comprehensive comparison of XLR and USB microphones for streaming, podcasting, and content creation. Learn which type is right for your setup with detailed pros, cons, and product recommendations.',
-  keywords: 'XLR vs USB microphones, best microphones for streaming, professional microphones, USB microphone comparison, XLR microphone setup, content creator microphones 2025'
+  keywords: 'XLR vs USB microphones, best microphones for streaming, professional microphones, USB microphone comparison, XLR microphone setup, content creator microphones 2025',
+  alternates: {
+    canonical: 'https://nextgenstreamer.com/guides/xlr-vs-usb-microphones-2025'
+  }
 }
 
 export default function XLRvsUSBMicrophonesPage() {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,6 +11,7 @@ import Script from 'next/script'
 const inter = Inter({ subsets: ['latin'] })
 
 export const metadata: Metadata = {
+  metadataBase: new URL('https://nextgenstreamer.com'),
   title: {
     default: 'NextGenStreamer - Best Creator Gear & Equipment 2025',
     template: '%s | NextGenStreamer'

--- a/app/legal/disclaimer/page.tsx
+++ b/app/legal/disclaimer/page.tsx
@@ -3,6 +3,9 @@ import { Metadata } from 'next/types'
 export const metadata: Metadata = {
   title: 'Affiliate Disclaimer - NextGenStreamer',
   description: 'Our affiliate disclaimer explains our relationship with Amazon and other retailers mentioned on our site.',
+  alternates: {
+    canonical: 'https://nextgenstreamer.com/legal/disclaimer'
+  }
 }
 
 export default function DisclaimerPage() {

--- a/app/legal/privacy/page.tsx
+++ b/app/legal/privacy/page.tsx
@@ -4,6 +4,9 @@ import CookiePreferences from '@/components/CookiePreferences'
 export const metadata: Metadata = {
   title: 'Privacy Policy - NextGenStreamer',
   description: 'Our privacy policy explains how we collect, use, and protect your information when you visit NextGenStreamer.',
+  alternates: {
+    canonical: 'https://nextgenstreamer.com/legal/privacy'
+  }
 }
 
 export default function PrivacyPage() {

--- a/app/lists/best-microphones-2025/page.tsx
+++ b/app/lists/best-microphones-2025/page.tsx
@@ -11,6 +11,9 @@ export const metadata: Metadata = {
     description: 'Discover the best microphones for podcasting, streaming, and content creation in 2025.',
     type: 'article',
   },
+  alternates: {
+    canonical: 'https://nextgenstreamer.com/lists/best-microphones-2025'
+  }
 }
 
 export default function BestMicrophonesPage() {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,13 @@ import Link from 'next/link'
 import AmazonProductCard from '@/components/AmazonProductCard'
 import AmazonCTAButton from '@/components/AmazonCTAButton'
 import { getFeaturedProducts } from '@/lib/products'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  alternates: {
+    canonical: 'https://nextgenstreamer.com/'
+  }
+}
 
 export default function Home() {
   const featuredProducts = getFeaturedProducts()

--- a/app/products/[slug]/page.tsx
+++ b/app/products/[slug]/page.tsx
@@ -37,6 +37,9 @@ export async function generateMetadata({ params }: ProductPageProps): Promise<Me
       images: [product.imageUrl],
       type: 'article',
     },
+    alternates: {
+      canonical: `https://nextgenstreamer.com/products/${slug}`
+    }
   }
 }
 

--- a/app/products/page.tsx
+++ b/app/products/page.tsx
@@ -11,6 +11,9 @@ export const metadata: Metadata = {
     description: 'Browse our complete collection of microphones, webcams, lighting, and streaming equipment for content creators.',
     type: 'website',
   },
+  alternates: {
+    canonical: 'https://nextgenstreamer.com/products'
+  }
 }
 
 export default function ProductsPage() {


### PR DESCRIPTION
## Summary
- set site `metadataBase` in layout
- add canonical links for all pages

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862c00220f8833290734e2b7e8b61ac