### PR TITLE
Add basic security headers

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,32 @@
 /** @type {import('next').NextConfig} */
+const securityHeaders = [
+  {
+    key: 'Content-Security-Policy',
+    value:
+      "default-src 'self'; img-src 'self' https://m.media-amazon.com https://images-na.ssl-images-amazon.com data: https://fonts.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com;",
+  },
+  {
+    key: 'Strict-Transport-Security',
+    value: 'max-age=63072000; includeSubDomains; preload',
+  },
+  {
+    key: 'X-Frame-Options',
+    value: 'SAMEORIGIN',
+  },
+  {
+    key: 'X-Content-Type-Options',
+    value: 'nosniff',
+  },
+  {
+    key: 'Referrer-Policy',
+    value: 'strict-origin-when-cross-origin',
+  },
+  {
+    key: 'Permissions-Policy',
+    value: 'camera=(), microphone=(), geolocation=()',
+  },
+]
+
 const nextConfig = {
   images: {
     domains: ['m.media-amazon.com', 'images-na.ssl-images-amazon.com'],
@@ -15,6 +43,14 @@ const nextConfig = {
   },
   experimental: {
     optimizePackageImports: ['lucide-react']
+  },
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: securityHeaders,
+      },
+    ]
   }
 }
 


### PR DESCRIPTION
## Summary
- set a group of security headers in `next.config.js`
- apply headers to every route

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864857bc3b08332ad6e123786db99f8