### PR TITLE
Add consent scripts and ads redirect

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -69,6 +69,27 @@ export default function RootLayout({
           async
           crossOrigin="anonymous"
         />
+        <Script
+          src="https://cmp.gatekeeperconsent.com/min.js"
+          strategy="afterInteractive"
+          data-cfasync="false"
+        />
+        <Script
+          src="https://the.gatekeeperconsent.com/cmp.min.js"
+          strategy="afterInteractive"
+          data-cfasync="false"
+        />
+        <Script
+          src="//www.ezojs.com/ezoic/sa.min.js"
+          strategy="afterInteractive"
+          async
+        />
+        <Script id="ezstandalone-init" strategy="afterInteractive">
+          {`
+            window.ezstandalone = window.ezstandalone || {};
+            ezstandalone.cmd = ezstandalone.cmd || [];
+          `}
+        </Script>
       </head>
       <body className={inter.className}>
         <GoogleAnalytics />

--- a/next.config.js
+++ b/next.config.js
@@ -44,6 +44,15 @@ const nextConfig = {
   experimental: {
     optimizePackageImports: ['lucide-react']
   },
+  async redirects() {
+    return [
+      {
+        source: '/ads.txt',
+        destination: 'https://srv.adstxtmanager.com/19390/nextgenstreamer.com',
+        permanent: true,
+      },
+    ]
+  },
   async headers() {
     return [
       {


### PR DESCRIPTION
## Summary
- inject gatekeeper and ezoic scripts in the root layout
- redirect `/ads.txt` to hosted ads.txt in `next.config.js`

## Testing
- `npm run build` *(fails: next not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68648a372b408332ad21eea107a52a49