### PR TITLE
Fix: Ensure mobile menu state toggles correctly

### DIFF
--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -91,7 +91,7 @@ export default function Navigation() {
 
           {/* Mobile menu button */}
           <button
-            onClick={() => setIsOpen(!isOpen)}
+            onClick={() => setIsOpen(prevIsOpen => !prevIsOpen)}
             className="md:hidden p-2 rounded-md text-text-primary hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-brand-primary transition-colors"
             aria-label="Toggle menu"
           >


### PR DESCRIPTION
Updated the onClick handler for the mobile menu button in Navigation.tsx to use the functional update form for `setIsOpen`. This should ensure the `isOpen` state is reliably toggled and the component re-renders correctly, fixing an issue where the menu icon was not changing and the menu panel was not expanding on mobile.