### PR TITLE
Fix: Condition AdSense script loading on cookie consent

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -62,13 +62,7 @@ export default function RootLayout({
         {/* ✅ Google AdSense Meta Tag for Instant Verification */}
         <meta name="google-adsense-account" content="ca-pub-2724823807720042" />
 
-        {/* ✅ Google AdSense Script to Enable Ads */}
-        <Script
-          src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2724823807720042"
-          strategy="afterInteractive"
-          async
-          crossOrigin="anonymous"
-        />
+        {/* 🚨 AdSense Script moved to CookieBanner to be loaded conditionally after consent */}
       </head>
       <body className={inter.className}>
         <GoogleAnalytics />

--- a/components/CookieBanner.tsx
+++ b/components/CookieBanner.tsx
@@ -55,6 +55,30 @@ export default function CookieBanner() {
               console.log('📊 Google Analytics loaded and tracking');
             `}
           </Script>
+          {/* ✅ Google AdSense Script to Enable Ads - Loaded Conditionally */}
+          <Script
+            src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-2724823807720042"
+            strategy="afterInteractive"
+            async
+            crossOrigin="anonymous"
+            onError={(e) => {
+              console.error('AdSense script failed to load:', e)
+            }}
+            onLoad={() => {
+              console.log('📰 AdSense script loaded successfully')
+            }}
+          />
+        </>
+      )}
+
+      {/* Cookie Banner */}
+      {showBanner && (
+              function gtag(){dataLayer.push(arguments);}
+              gtag('js', new Date());
+              gtag('config', 'G-P9TMPE87N7');
+              console.log('📊 Google Analytics loaded and tracking');
+            `}
+          </Script>
         </>
       )}
 


### PR DESCRIPTION
- Moved Google AdSense script from app/layout.tsx to components/CookieBanner.tsx.
- AdSense script will now only load after user provides consent via the cookie banner, similar to Google Analytics.
- This change aims to resolve privacy warnings displayed by Safari's Intelligent Tracking Prevention in Private Browsing mode by preventing unconditional loading of advertising/tracking scripts.