### PR TITLE
Fix: Update CSP to allow cookie banner scripts

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,7 +3,7 @@ const securityHeaders = [
   {
     key: 'Content-Security-Policy',
     value:
-      "default-src 'self'; img-src 'self' https://m.media-amazon.com https://images-na.ssl-images-amazon.com data: https://fonts.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com;",
+      "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://pagead2.googlesyndication.com; connect-src 'self' https://www.google-analytics.com https://analytics.google.com; img-src 'self' https://m.media-amazon.com https://images-na.ssl-images-amazon.com data: https://fonts.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; frame-src 'self' https://www.googletagmanager.com;",
   },
   {
     key: 'Strict-Transport-Security',


### PR DESCRIPTION
Updated the Content Security Policy in `next.config.js` to include the necessary directives for Google Analytics, Google Tag Manager, AdSense, and to allow the inline scripts used by the cookie consent mechanism.

This should resolve the issue of the cookie banner not appearing due to CSP violations.